### PR TITLE
service: account

### DIFF
--- a/account/create_request.go
+++ b/account/create_request.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type CreateRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}
+
+func (req *CreateRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/account/create_service.go
+++ b/account/create_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Create(req *CreateRequest) (*v1.Account, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.Account, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewAccountOp(s.client)
+	return client.Create(ctx, req.SiteId)
+}

--- a/account/delete_request.go
+++ b/account/delete_request.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type DeleteRequest struct {
+	SiteId string `service:"-" validate:"required"`
+	Id     string `service:"-" validate:"required"` // リソースId
+}
+
+func (req *DeleteRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/account/delete_service.go
+++ b/account/delete_service.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	_, err := s.ReadWithContext(ctx, &ReadRequest{
+		SiteId: req.SiteId,
+		Id:     req.Id,
+	})
+	if err != nil {
+		return err
+	}
+
+	client := objectstorage.NewAccountOp(s.client)
+	return client.Delete(ctx, req.SiteId)
+}

--- a/account/find_request.go
+++ b/account/find_request.go
@@ -1,0 +1,25 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import "github.com/sacloud/packages-go/validate"
+
+type FindRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/account/find_service.go
+++ b/account/find_service.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*v1.Account, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.Account, error) {
+	if req == nil {
+		req = &FindRequest{}
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := objectstorage.NewAccountOp(s.client)
+	account, err := client.Read(ctx, req.SiteId)
+	if err != nil {
+		// Note: serviceインターフェースを満たすためにclient.Read()が404エラーを返した時はエラーではなく[]*v1.Account{}を返す
+		if _, ok := err.(*v1.Error404); ok {
+			return []*v1.Account{}, nil
+		}
+		return nil, err
+	}
+	return []*v1.Account{account}, nil
+}

--- a/account/read_request.go
+++ b/account/read_request.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type ReadRequest struct {
+	SiteId string `service:"-" validate:"required"`
+	Id     string `service:"-" validate:"required"` // リソースId
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/account/read_service.go
+++ b/account/read_service.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"context"
+	"fmt"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	service "github.com/sacloud/object-storage-service-go"
+)
+
+func (s *Service) Read(req *ReadRequest) (*v1.Account, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.Account, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewAccountOp(s.client)
+	account, err := client.Read(ctx, req.SiteId)
+	if err != nil {
+		return nil, err
+	}
+	if account.ResourceId.String() == req.Id {
+		return account, nil
+	}
+	return nil, service.NotFoundError(fmt.Errorf("account %q not found", req.Id))
+}

--- a/account/service.go
+++ b/account/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import objectstorage "github.com/sacloud/object-storage-api-go"
+
+// Service provides a high-level API of for Site
+type Service struct {
+	client *objectstorage.Client
+}
+
+// New returns new service instance of Archive
+func New(client *objectstorage.Client) *Service {
+	return &Service{client: client}
+}

--- a/account/service_test.go
+++ b/account/service_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package account
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/object-storage-api-go/fake"
+	"github.com/sacloud/object-storage-api-go/fake/server"
+	service "github.com/sacloud/object-storage-service-go"
+	"github.com/stretchr/testify/require"
+)
+
+var siteId = "isk01"
+
+func TestService_CRUD_plus_L(t *testing.T) {
+	server := initFakeServer()
+	client := &objectstorage.Client{
+		APIRootURL: server.URL,
+	}
+	svc := New(client)
+	var account *v1.Account
+
+	t.Run("create", func(t *testing.T) {
+		created, err := svc.Create(&CreateRequest{
+			SiteId: siteId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		account = created
+	})
+
+	t.Run("read", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{
+			SiteId: siteId,
+			Id:     account.ResourceId.String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, read)
+	})
+
+	t.Run("read return NotFoundError when account is not found", func(t *testing.T) {
+		id := "not-exists-account-id"
+		read, err := svc.Read(&ReadRequest{
+			SiteId: siteId,
+			Id:     id,
+		})
+		require.Nil(t, read)
+		require.EqualError(t, err, `account "`+id+`" not found`)
+
+		_, errIsNotFoundError := err.(service.NotFoundError)
+		require.True(t, errIsNotFoundError)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{
+			SiteId: siteId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+		require.Equal(t, account, found[0])
+	})
+
+	t.Run("delete return NotFoundError when account is not found", func(t *testing.T) {
+		id := "not-exists-account-id"
+		err := svc.Delete(&DeleteRequest{
+			SiteId: siteId,
+			Id:     id,
+		})
+		require.EqualError(t, err, `account "`+id+`" not found`)
+
+		_, errIsNotFoundError := err.(service.NotFoundError)
+		require.True(t, errIsNotFoundError)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := svc.Delete(&DeleteRequest{
+			SiteId: siteId,
+			Id:     account.ResourceId.String(),
+		})
+		require.NoError(t, err)
+
+		found, err := svc.Find(&FindRequest{
+			SiteId: siteId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 0)
+	})
+}
+
+func initFakeServer() *httptest.Server {
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Clusters: []*v1.Cluster{
+				{
+					Id:              siteId,
+					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
+					DisplayNameEnUs: "Ishikari Site #1",
+					DisplayNameJa:   "石狩第1サイト",
+					DisplayName:     "石狩第1サイト",
+					DisplayOrder:    1,
+					EndpointBase:    "isk01.sakurastorage.jp",
+				},
+			},
+		},
+	}
+	return httptest.NewServer(fakeServer.Handler())
+}

--- a/bucket/read_service.go
+++ b/bucket/read_service.go
@@ -17,6 +17,8 @@ package bucket
 import (
 	"context"
 	"fmt"
+
+	service "github.com/sacloud/object-storage-service-go"
 )
 
 // Read バケットの参照
@@ -49,12 +51,9 @@ func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*Bucke
 			return bucket, nil
 		}
 	}
-	var e error = NotFoundError(fmt.Errorf("bucket %q not found", req.Id))
-	if _, ok := e.(NotFoundError); ok {
+	var e error = service.NotFoundError(fmt.Errorf("bucket %q not found", req.Id))
+	if _, ok := e.(service.NotFoundError); ok {
 		fmt.Println("foo")
 	}
-	return nil, NotFoundError(fmt.Errorf("bucket %q not found", req.Id))
+	return nil, service.NotFoundError(fmt.Errorf("bucket %q not found", req.Id))
 }
-
-// NotFoundError バケットが見つからなかった時のエラー
-type NotFoundError error

--- a/bucket/service_acc_test.go
+++ b/bucket/service_acc_test.go
@@ -75,7 +75,7 @@ func TestAccService_CRUD_plus_L(t *testing.T) {
 		})
 		require.EqualError(t, err, `bucket "`+notExistName+`" not found`)
 
-		_, errIsNotFoundError := err.(NotFoundError)
+		_, errIsNotFoundError := err.(service.NotFoundError)
 		require.True(t, errIsNotFoundError)
 	})
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+// NotFoundError 対象リソースが見つからなかったことを示すエラー
+type NotFoundError error

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.25.0
 	github.com/sacloud/api-client-go v0.0.3
-	github.com/sacloud/object-storage-api-go v0.0.4
+	github.com/sacloud/object-storage-api-go v0.0.5-0.20220323131139-89c78dc904c0
 	github.com/sacloud/packages-go v0.0.2
 	github.com/stretchr/testify v1.7.0
 )
@@ -29,6 +29,7 @@ require (
 	github.com/aws/smithy-go v1.11.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.9.1 // indirect
+	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.7.4 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/deepmap/oapi-codegen v1.9.1 h1:yHmEnA7jSTUMQgV+uN02WpZtwHnz2CBW3mZRIx
 github.com/deepmap/oapi-codegen v1.9.1/go.mod h1:PLqNAhdedP8ttRpBBkzLKU3bp+Fpy+tTgeAMlztR2cw=
 github.com/getkin/kin-openapi v0.87.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a h1:yU/FENpkHYISWsQrbr3pcZOBj0EuRjPzNc1+dTCLu44=
+github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a/go.mod h1:AEugkNu3BjBxyz958nJ5holD9PRjta6iprcoUauDbU4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -135,8 +136,8 @@ github.com/sacloud/api-client-go v0.0.3 h1:9xGKuBzWaYribd4jmq1Fe8Uijtr3taL9dwYKF
 github.com/sacloud/api-client-go v0.0.3/go.mod h1:fisKcJ5DUIPx+PpNrH+118tZ2ejp+pM6R+xEiICuv/Q=
 github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
-github.com/sacloud/object-storage-api-go v0.0.4 h1:Qqgqrop7rhLuE1IdljB34EXd398tmtScYeMTFOoDdJA=
-github.com/sacloud/object-storage-api-go v0.0.4/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
+github.com/sacloud/object-storage-api-go v0.0.5-0.20220323131139-89c78dc904c0 h1:qG/A91XdlwRoPyJvN2JdkYEuh/K8C6iSOFp/8lKU1bo=
+github.com/sacloud/object-storage-api-go v0.0.5-0.20220323131139-89c78dc904c0/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
 github.com/sacloud/packages-go v0.0.2 h1:tvA/V8tjzaCeuQQVwby1Olq6RmjMI/LEdAe65+qcpYM=
 github.com/sacloud/packages-go v0.0.2/go.mod h1:Eny1qnbKr9n/5yfXDiwOC+0YMiBhK1HBYGjjmxes+CI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
サイトアカウントに対するCreate / Read / Delete / List操作を提供する。

```go
    func (s *Service) Create(req *CreateRequest) (*v1.Account, error)
    func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.Account, error)

    func (s *Service) Delete(req *DeleteRequest) error
    func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error

    func (s *Service) Find(req *FindRequest) ([]*v1.Account, error)
    func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.Account, error)

    func (s *Service) Read(req *ReadRequest) (*v1.Account, error)
    func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.Account, error)
```

Note: アカウントキー関連の操作は別サービス(別パッケージ)として提供する。

Note: object-storage-api-goのレベルではサイトに対してアカウントは1つしか持てないため、Find/Readの区別はなく、アカウントのIDを受け取るようなインターフェースは提供していない。
object-storage-service-goでは他のサービスとインターフェースを揃えるために上記をラップしたインターフェースを提供する。

