### PR TITLE
service: permission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.25.0
 	github.com/sacloud/api-client-go v0.0.3
-	github.com/sacloud/object-storage-api-go v0.0.6-0.20220324003440-e04fbf8842c6
+	github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96
 	github.com/sacloud/packages-go v0.0.2
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/sacloud/api-client-go v0.0.3 h1:9xGKuBzWaYribd4jmq1Fe8Uijtr3taL9dwYKF
 github.com/sacloud/api-client-go v0.0.3/go.mod h1:fisKcJ5DUIPx+PpNrH+118tZ2ejp+pM6R+xEiICuv/Q=
 github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
-github.com/sacloud/object-storage-api-go v0.0.6-0.20220324003440-e04fbf8842c6 h1:Uq0QrHwEccoSkK7l7yATtI/uEpqO2vCrvMAvaDP/XXo=
-github.com/sacloud/object-storage-api-go v0.0.6-0.20220324003440-e04fbf8842c6/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
+github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96 h1:ZNsn6aibPsmesqrWK3aox0uYhPTvYbsKuBRul421Plg=
+github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
 github.com/sacloud/packages-go v0.0.2 h1:tvA/V8tjzaCeuQQVwby1Olq6RmjMI/LEdAe65+qcpYM=
 github.com/sacloud/packages-go v0.0.2/go.mod h1:Eny1qnbKr9n/5yfXDiwOC+0YMiBhK1HBYGjjmxes+CI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/permission/create_request.go
+++ b/permission/create_request.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/packages-go/validate"
+)
+
+type CreateRequest struct {
+	SiteId         string           `service:"-" validate:"required"`
+	DisplayName    string           `validate:"required"`
+	BucketControls []*BucketControl `validate:"omitempty,dive,required"`
+}
+
+func (req *CreateRequest) Validate() error {
+	return validate.New().Struct(req)
+}
+
+func (req *CreateRequest) ToRequestParameter() *v1.CreatePermissionParams {
+	p := &v1.CreatePermissionParams{
+		BucketControls: v1.BucketControls{},
+		DisplayName:    v1.DisplayName(req.DisplayName),
+	}
+	for _, bc := range req.BucketControls {
+		p.BucketControls = append(p.BucketControls, v1.BucketControl{
+			BucketName: v1.BucketName(bc.BucketName),
+			CanRead:    v1.CanRead(bc.CanRead),
+			CanWrite:   v1.CanWrite(bc.CanWrite),
+		})
+	}
+	return p
+}

--- a/permission/create_request_test.go
+++ b/permission/create_request_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import "testing"
+
+func TestCreateRequest_Validate(t *testing.T) {
+	type fields struct {
+		SiteId         string
+		DisplayName    string
+		BucketControls []*BucketControl
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "minimum",
+			fields: fields{
+				SiteId:         "isk01",
+				DisplayName:    "minimum",
+				BucketControls: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with bucket controls",
+			fields: fields{
+				SiteId:      "isk01",
+				DisplayName: "with bucket controls",
+				BucketControls: []*BucketControl{
+					{BucketName: "bucket"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid bucket controls",
+			fields: fields{
+				SiteId:      "isk01",
+				DisplayName: "invalid bucket controls",
+				BucketControls: []*BucketControl{
+					nil,
+					{BucketName: "bucket"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CreateRequest{
+				SiteId:         tt.fields.SiteId,
+				DisplayName:    tt.fields.DisplayName,
+				BucketControls: tt.fields.BucketControls,
+			}
+			if err := req.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/permission/create_service.go
+++ b/permission/create_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Create(req *CreateRequest) (*v1.Permission, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.Permission, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	return client.Create(ctx, req.SiteId, req.ToRequestParameter())
+}

--- a/permission/delete_request.go
+++ b/permission/delete_request.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type DeleteRequest struct {
+	SiteId string `service:"-" validate:"required"`
+	Id     int64  `service:"-" validate:"required"` // リソースId
+}
+
+func (req *DeleteRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/delete_service.go
+++ b/permission/delete_service.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	_, err := s.ReadWithContext(ctx, &ReadRequest{
+		SiteId: req.SiteId,
+		Id:     req.Id,
+	})
+	if err != nil {
+		return err
+	}
+
+	client := objectstorage.NewPermissionOp(s.client)
+	return client.Delete(ctx, req.SiteId, req.Id)
+}

--- a/permission/find_request.go
+++ b/permission/find_request.go
@@ -1,0 +1,25 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import "github.com/sacloud/packages-go/validate"
+
+type FindRequest struct {
+	SiteId string `service:"-" validate:"required"`
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/find_service.go
+++ b/permission/find_service.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*v1.Permission, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.Permission, error) {
+	if req == nil {
+		req = &FindRequest{}
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := objectstorage.NewPermissionOp(s.client)
+	return client.List(ctx, req.SiteId)
+}

--- a/permission/read_request.go
+++ b/permission/read_request.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type ReadRequest struct {
+	SiteId string `service:"-" validate:"required"`
+	Id     int64  `service:"-" validate:"required"` // リソースId
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/read_service.go
+++ b/permission/read_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Read(req *ReadRequest) (*v1.Permission, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.Permission, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	return client.Read(ctx, req.SiteId, req.Id)
+}

--- a/permission/service.go
+++ b/permission/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import objectstorage "github.com/sacloud/object-storage-api-go"
+
+// Service provides a high-level API of for Site
+type Service struct {
+	client *objectstorage.Client
+}
+
+// New returns new service instance of Archive
+func New(client *objectstorage.Client) *Service {
+	return &Service{client: client}
+}

--- a/permission/service_test.go
+++ b/permission/service_test.go
@@ -1,0 +1,136 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/object-storage-api-go/fake"
+	"github.com/sacloud/object-storage-api-go/fake/server"
+	"github.com/sacloud/packages-go/pointer"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var siteId = "isk01"
+
+func TestService_CRUD_plus_L(t *testing.T) {
+	server := initFakeServer()
+	client := &objectstorage.Client{
+		APIRootURL: server.URL,
+	}
+	svc := New(client)
+	var permission *v1.Permission
+
+	t.Run("create", func(t *testing.T) {
+		created, err := svc.Create(&CreateRequest{
+			SiteId:      siteId,
+			DisplayName: testutil.Random(16, testutil.CharSetAlpha),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		permission = created
+	})
+
+	t.Run("read", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{
+			SiteId: siteId,
+			Id:     permission.Id.Int64(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, read)
+	})
+
+	t.Run("read return NotFoundError when account is not found", func(t *testing.T) {
+		id := int64(123456789012)
+		read, err := svc.Read(&ReadRequest{
+			SiteId: siteId,
+			Id:     id,
+		})
+		require.Nil(t, read)
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
+	})
+
+	t.Run("list", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{
+			SiteId: siteId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+
+		require.Equal(t, permission, found[0])
+	})
+
+	t.Run("update", func(t *testing.T) {
+		updatedName := permission.DisplayName.String() + "-updated"
+		updated, err := svc.Update(&UpdateRequest{
+			SiteId:      siteId,
+			Id:          permission.Id.Int64(),
+			DisplayName: pointer.NewString(updatedName),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, updatedName, updated.DisplayName.String())
+		require.Equal(t, permission.BucketControls, updated.BucketControls)
+	})
+
+	t.Run("delete return NotFoundError when account is not found", func(t *testing.T) {
+		id := int64(123456789012)
+		err := svc.Delete(&DeleteRequest{
+			SiteId: siteId,
+			Id:     id,
+		})
+
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := svc.Delete(&DeleteRequest{
+			SiteId: siteId,
+			Id:     permission.Id.Int64(),
+		})
+		require.NoError(t, err)
+
+		found, err := svc.Find(&FindRequest{
+			SiteId: siteId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 0)
+	})
+}
+
+func initFakeServer() *httptest.Server {
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Clusters: []*v1.Cluster{
+				{
+					Id:              siteId,
+					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
+					DisplayNameEnUs: "Ishikari Site #1",
+					DisplayNameJa:   "石狩第1サイト",
+					DisplayName:     "石狩第1サイト",
+					DisplayOrder:    1,
+					EndpointBase:    "isk01.sakurastorage.jp",
+				},
+			},
+		},
+	}
+	return httptest.NewServer(fakeServer.Handler())
+}

--- a/permission/types.go
+++ b/permission/types.go
@@ -1,0 +1,21 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+type BucketControl struct {
+	BucketName string `validate:"required"`
+	CanRead    bool
+	CanWrite   bool
+}

--- a/permission/update_request.go
+++ b/permission/update_request.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/packages-go/validate"
+)
+
+type UpdateRequest struct {
+	SiteId         string            `service:"-" validate:"required"`
+	Id             int64             `service:"-" validate:"required"`
+	DisplayName    *string           `validate:"omitempty"`
+	BucketControls *[]*BucketControl `validate:"omitempty,dive,required"`
+}
+
+func (req *UpdateRequest) Validate() error {
+	return validate.New().Struct(req)
+}
+
+func (req *UpdateRequest) ToRequestParameter(current *v1.Permission) *v1.UpdatePermissionParams {
+	p := &v1.UpdatePermissionParams{
+		BucketControls: current.BucketControls,
+		DisplayName:    current.DisplayName,
+	}
+	if req.DisplayName != nil {
+		p.DisplayName = v1.DisplayName(*req.DisplayName)
+	}
+
+	if req.BucketControls != nil {
+		p.BucketControls = v1.BucketControls{}
+		for _, bc := range *req.BucketControls {
+			p.BucketControls = append(p.BucketControls, v1.BucketControl{
+				BucketName: v1.BucketName(bc.BucketName),
+				CanRead:    v1.CanRead(bc.CanRead),
+				CanWrite:   v1.CanWrite(bc.CanWrite),
+			})
+		}
+	}
+	return p
+}

--- a/permission/update_service.go
+++ b/permission/update_service.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Update(req *UpdateRequest) (*v1.Permission, error) {
+	return s.UpdateWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*v1.Permission, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+
+	current, err := client.Read(ctx, req.SiteId, req.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Update(ctx, req.SiteId, req.Id, req.ToRequestParameter(current))
+}


### PR DESCRIPTION
Note: Update時のネストしたフィールドに対しては部分置き換えではなく一括置き換えとする。

```go
type UpdateRequest struct {
	SiteId         string            `service:"-" validate:"required"`
	Id             int64             `service:"-" validate:"required"`
	DisplayName    *string           `validate:"omitempty"`
	BucketControls *[]*BucketControl `validate:"omitempty,dive,required"`
}
```

上記の例だとBucketControlsは指定された場合は置き換えられる。
バケット名をキーにマージはしない。