### PR TITLE
パッケージ構造とリソースの論理階層を一致させる

### DIFF
--- a/account/accesskey/create_request.go
+++ b/account/accesskey/create_request.go
@@ -12,27 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
-	"context"
-
-	objectstorage "github.com/sacloud/object-storage-api-go"
-	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/packages-go/validate"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*v1.AccountKey, error) {
-	return s.FindWithContext(context.Background(), req)
+type CreateRequest struct {
+	SiteId string `service:"-" validate:"required"`
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.AccountKey, error) {
-	if req == nil {
-		req = &FindRequest{}
-	}
-	if err := req.Validate(); err != nil {
-		return nil, err
-	}
-
-	client := objectstorage.NewAccountOp(s.client)
-	return client.ListAccessKeys(ctx, req.SiteId)
+func (req *CreateRequest) Validate() error {
+	return validate.New().Struct(req)
 }

--- a/account/accesskey/create_service.go
+++ b/account/accesskey/create_service.go
@@ -12,14 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
-import "github.com/sacloud/packages-go/validate"
+import (
+	"context"
 
-type FindRequest struct {
-	SiteId string `service:"-" validate:"required"`
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Create(req *CreateRequest) (*v1.AccountKey, error) {
+	return s.CreateWithContext(context.Background(), req)
 }
 
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.AccountKey, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewAccountOp(s.client)
+	return client.CreateAccessKey(ctx, req.SiteId)
 }

--- a/account/accesskey/delete_request.go
+++ b/account/accesskey/delete_request.go
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
-import objectstorage "github.com/sacloud/object-storage-api-go"
+import (
+	"github.com/sacloud/packages-go/validate"
+)
 
-// Service provides a high-level API of for Site
-type Service struct {
-	client *objectstorage.Client
+type DeleteRequest struct {
+	SiteId string `service:"-" validate:"required"`
+	Id     string `service:"-" validate:"required"` // リソースId
 }
 
-// New returns new service instance of Archive
-func New(client *objectstorage.Client) *Service {
-	return &Service{client: client}
+func (req *DeleteRequest) Validate() error {
+	return validate.New().Struct(req)
 }

--- a/account/accesskey/delete_service.go
+++ b/account/accesskey/delete_service.go
@@ -12,16 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
-	"github.com/sacloud/packages-go/validate"
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
 )
 
-type CreateRequest struct {
-	SiteId string `service:"-" validate:"required"`
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
 }
 
-func (req *CreateRequest) Validate() error {
-	return validate.New().Struct(req)
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	_, err := s.ReadWithContext(ctx, &ReadRequest{
+		SiteId: req.SiteId,
+		Id:     req.Id,
+	})
+	if err != nil {
+		return err
+	}
+
+	client := objectstorage.NewAccountOp(s.client)
+	return client.DeleteAccessKey(ctx, req.SiteId, req.Id)
 }

--- a/account/accesskey/find_request.go
+++ b/account/accesskey/find_request.go
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
+import "github.com/sacloud/packages-go/validate"
 
-type DeleteRequest struct {
+type FindRequest struct {
 	SiteId string `service:"-" validate:"required"`
-	Id     string `service:"-" validate:"required"` // リソースId
 }
 
-func (req *DeleteRequest) Validate() error {
+func (req *FindRequest) Validate() error {
 	return validate.New().Struct(req)
 }

--- a/account/accesskey/find_service.go
+++ b/account/accesskey/find_service.go
@@ -12,30 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
 	"context"
 
 	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
 )
 
-func (s *Service) Delete(req *DeleteRequest) error {
-	return s.DeleteWithContext(context.Background(), req)
+func (s *Service) Find(req *FindRequest) ([]*v1.AccountKey, error) {
+	return s.FindWithContext(context.Background(), req)
 }
 
-func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
-	if err := req.Validate(); err != nil {
-		return err
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.AccountKey, error) {
+	if req == nil {
+		req = &FindRequest{}
 	}
-	_, err := s.ReadWithContext(ctx, &ReadRequest{
-		SiteId: req.SiteId,
-		Id:     req.Id,
-	})
-	if err != nil {
-		return err
+	if err := req.Validate(); err != nil {
+		return nil, err
 	}
 
 	client := objectstorage.NewAccountOp(s.client)
-	return client.DeleteAccessKey(ctx, req.SiteId, req.Id)
+	return client.ListAccessKeys(ctx, req.SiteId)
 }

--- a/account/accesskey/read_request.go
+++ b/account/accesskey/read_request.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
 	"github.com/sacloud/packages-go/validate"

--- a/account/accesskey/read_service.go
+++ b/account/accesskey/read_service.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
 	"context"

--- a/account/accesskey/service.go
+++ b/account/accesskey/service.go
@@ -12,23 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
-import (
-	"context"
+import objectstorage "github.com/sacloud/object-storage-api-go"
 
-	objectstorage "github.com/sacloud/object-storage-api-go"
-	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
-)
-
-func (s *Service) Create(req *CreateRequest) (*v1.AccountKey, error) {
-	return s.CreateWithContext(context.Background(), req)
+// Service provides a high-level API of for Site
+type Service struct {
+	client *objectstorage.Client
 }
 
-func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.AccountKey, error) {
-	if err := req.Validate(); err != nil {
-		return nil, err
-	}
-	client := objectstorage.NewAccountOp(s.client)
-	return client.CreateAccessKey(ctx, req.SiteId)
+// New returns new service instance of Archive
+func New(client *objectstorage.Client) *Service {
+	return &Service{client: client}
 }

--- a/account/accesskey/service_test.go
+++ b/account/accesskey/service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package accountkey
+package accesskey
 
 import (
 	"net/http/httptest"

--- a/site/status/read_request.go
+++ b/site/status/read_request.go
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sitestatus
+package status
 
-import objectstorage "github.com/sacloud/object-storage-api-go"
+import (
+	"github.com/sacloud/packages-go/validate"
+)
 
-// Service provides a high-level API of for Site
-type Service struct {
-	client *objectstorage.Client
+type ReadRequest struct {
+	Id string `service:"-" validate:"required"`
 }
 
-// New returns new service instance of Archive
-func New(client *objectstorage.Client) *Service {
-	return &Service{client: client}
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
 }

--- a/site/status/read_service.go
+++ b/site/status/read_service.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sitestatus
+package status
 
 import (
 	"context"

--- a/site/status/service.go
+++ b/site/status/service.go
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sitestatus
+package status
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
+import objectstorage "github.com/sacloud/object-storage-api-go"
 
-type ReadRequest struct {
-	Id string `service:"-" validate:"required"`
+// Service provides a high-level API of for Site
+type Service struct {
+	client *objectstorage.Client
 }
 
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
+// New returns new service instance of Archive
+func New(client *objectstorage.Client) *Service {
+	return &Service{client: client}
 }

--- a/site/status/service_test.go
+++ b/site/status/service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sitestatus
+package status
 
 import (
 	"net/http/httptest"


### PR DESCRIPTION
パッケージ構造をリソースの親子構造を反映したものにする。
これによりパッケージ構造は以下のようになる。

```console
.
├── account
│   └── accesskey
├── bucket
├── permission
│   └── accesskey(未実装)
└── site
    └── status
```

---

従来のサービス(iaas-service-go)ではパッケージ階層はフラットにしていた。
これはUsacloudなどでのコード生成の都合によるものだったが、今後のサービスではメタデータ(カタログ)を提供することによりパッケージ階層は比較的自由となる。
このためより元のリソースに近い論理階層をそのままパッケージ構造とした方が利用者側も覚えやすく使いやすいと判断した。
