### PR TITLE
service: permission/bucket-control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.25.0
 	github.com/sacloud/api-client-go v0.0.3
-	github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96
+	github.com/sacloud/object-storage-api-go v0.0.6-0.20220324081050-d4910a5da87a
 	github.com/sacloud/packages-go v0.0.2
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/sacloud/api-client-go v0.0.3 h1:9xGKuBzWaYribd4jmq1Fe8Uijtr3taL9dwYKF
 github.com/sacloud/api-client-go v0.0.3/go.mod h1:fisKcJ5DUIPx+PpNrH+118tZ2ejp+pM6R+xEiICuv/Q=
 github.com/sacloud/go-http v0.0.4 h1:+vgx/uCctcGiHMe8jE+qirMKd3+d73MNZXK7nrUo0po=
 github.com/sacloud/go-http v0.0.4/go.mod h1:aYTXNuAnPmD6Ar3ktDaR1gPxJCPv2CqpppcYciy1hmo=
-github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96 h1:ZNsn6aibPsmesqrWK3aox0uYhPTvYbsKuBRul421Plg=
-github.com/sacloud/object-storage-api-go v0.0.6-0.20220324052655-2a3ee1db4f96/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
+github.com/sacloud/object-storage-api-go v0.0.6-0.20220324081050-d4910a5da87a h1:1PA0wvn1vIJNENxXtoMfQRfWSylFBNs2LMhNq+bO97U=
+github.com/sacloud/object-storage-api-go v0.0.6-0.20220324081050-d4910a5da87a/go.mod h1:zbPyMvPwRZA8PToJotYkOv1o9btdHdGjWkeHj58PhfE=
 github.com/sacloud/packages-go v0.0.2 h1:tvA/V8tjzaCeuQQVwby1Olq6RmjMI/LEdAe65+qcpYM=
 github.com/sacloud/packages-go v0.0.2/go.mod h1:Eny1qnbKr9n/5yfXDiwOC+0YMiBhK1HBYGjjmxes+CI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/permission/bucketcontrol/create_request.go
+++ b/permission/bucketcontrol/create_request.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type CreateRequest struct {
+	SiteId       string `service:"-" validate:"required"`
+	PermissionId int64  `service:"-" validate:"required"`
+	BucketName   string `validate:"required"`
+	CanRead      bool
+	CanWrite     bool
+}
+
+func (req *CreateRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/bucketcontrol/create_service.go
+++ b/permission/bucketcontrol/create_service.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Create(req *CreateRequest) (*v1.BucketControl, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*v1.BucketControl, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	permission, err := client.Read(ctx, req.SiteId, req.PermissionId)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, bc := range permission.BucketControls {
+		if bc.BucketName.String() == req.BucketName {
+			return nil, &v1.Error409{
+				Detail: v1.ErrorDetail{
+					Code:    http.StatusConflict,
+					Message: v1.ErrorMessage(fmt.Sprintf("bucket control for %q already exist", req.BucketName)),
+				},
+			}
+		}
+	}
+
+	permission.BucketControls = append(permission.BucketControls, v1.BucketControl{
+		BucketName: v1.BucketName(req.BucketName),
+		CanRead:    v1.CanRead(req.CanRead),
+		CanWrite:   v1.CanWrite(req.CanWrite),
+	})
+	permission, err = client.Update(ctx, req.SiteId, req.PermissionId, &v1.UpdatePermissionParams{
+		BucketControls: permission.BucketControls,
+		DisplayName:    permission.DisplayName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, bc := range permission.BucketControls {
+		if bc.BucketName.String() == req.BucketName {
+			return &bc, nil
+		}
+	}
+
+	// 到達しないはず(さくらのクラウド側の障害というケースがあり得るためpanicはさせない)
+	return nil, fmt.Errorf("created bucket-control not found")
+}

--- a/permission/bucketcontrol/delete_request.go
+++ b/permission/bucketcontrol/delete_request.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type DeleteRequest struct {
+	SiteId       string `service:"-" validate:"required"`
+	PermissionId int64  `service:"-" validate:"required"`
+	BucketName   string `validate:"required"`
+}
+
+func (req *DeleteRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/bucketcontrol/delete_service.go
+++ b/permission/bucketcontrol/delete_service.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	permission, err := client.Read(ctx, req.SiteId, req.PermissionId)
+	if err != nil {
+		return err
+	}
+
+	var bucketControls v1.BucketControls
+	for _, bc := range permission.BucketControls {
+		if bc.BucketName.String() != req.BucketName {
+			bucketControls = append(bucketControls, bc)
+		}
+	}
+
+	if len(bucketControls) == len(permission.BucketControls) {
+		return &v1.Error404{
+			Detail: v1.ErrorDetail{
+				Code:    http.StatusNotFound,
+				Message: v1.ErrorMessage(fmt.Sprintf("bucket control for %q not found", req.BucketName)),
+			},
+		}
+	}
+	permission.BucketControls = bucketControls
+
+	_, err = client.Update(ctx, req.SiteId, req.PermissionId, &v1.UpdatePermissionParams{
+		BucketControls: permission.BucketControls,
+		DisplayName:    permission.DisplayName,
+	})
+	return err
+}

--- a/permission/bucketcontrol/find_request.go
+++ b/permission/bucketcontrol/find_request.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import "github.com/sacloud/packages-go/validate"
+
+type FindRequest struct {
+	SiteId       string `service:"-" validate:"required"`
+	PermissionId int64  `service:"-" validate:"required"`
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/bucketcontrol/find_service.go
+++ b/permission/bucketcontrol/find_service.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"context"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*v1.BucketControl, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.BucketControl, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	permission, err := client.Read(ctx, req.SiteId, req.PermissionId)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*v1.BucketControl
+	for _, bc := range permission.BucketControls {
+		results = append(results, &bc)
+	}
+	return results, nil
+}

--- a/permission/bucketcontrol/read_request.go
+++ b/permission/bucketcontrol/read_request.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import "github.com/sacloud/packages-go/validate"
+
+type ReadRequest struct {
+	SiteId       string `service:"-" validate:"required"`
+	PermissionId int64  `service:"-" validate:"required"`
+	BucketName   string `validate:"required"`
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/bucketcontrol/read_service.go
+++ b/permission/bucketcontrol/read_service.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Read(req *ReadRequest) (*v1.BucketControl, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.BucketControl, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	permission, err := client.Read(ctx, req.SiteId, req.PermissionId)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, bc := range permission.BucketControls {
+		if bc.BucketName.String() == req.BucketName {
+			return &bc, nil
+		}
+	}
+
+	return nil, &v1.Error404{
+		Detail: v1.ErrorDetail{
+			Code:    http.StatusNotFound,
+			Message: v1.ErrorMessage(fmt.Sprintf("bucket control for %q not found", req.BucketName)),
+		},
+	}
+}

--- a/permission/bucketcontrol/service.go
+++ b/permission/bucketcontrol/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import objectstorage "github.com/sacloud/object-storage-api-go"
+
+// Service provides a high-level API of for Site
+type Service struct {
+	client *objectstorage.Client
+}
+
+// New returns new service instance of Archive
+func New(client *objectstorage.Client) *Service {
+	return &Service{client: client}
+}

--- a/permission/bucketcontrol/service_test.go
+++ b/permission/bucketcontrol/service_test.go
@@ -1,0 +1,160 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+	"github.com/sacloud/object-storage-api-go/fake"
+	"github.com/sacloud/object-storage-api-go/fake/server"
+	"github.com/sacloud/packages-go/pointer"
+	"github.com/sacloud/packages-go/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var siteId = "isk01"
+var permissionId = int64(100000001)
+var bucketName = testutil.Random(16, testutil.CharSetAlpha)
+
+func TestService_CRUD_plus_L(t *testing.T) {
+	fakeServer := initFakeServer()
+	client := &objectstorage.Client{
+		APIRootURL: fakeServer.URL,
+	}
+	svc := New(client)
+	var bucketControl *v1.BucketControl
+
+	t.Run("create", func(t *testing.T) {
+		created, err := svc.Create(&CreateRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   bucketName,
+			CanRead:      true,
+			CanWrite:     true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		bucketControl = created
+	})
+
+	t.Run("read", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   bucketName,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, read)
+
+		require.True(t, read.CanRead.Bool())
+		require.True(t, read.CanWrite.Bool())
+	})
+
+	t.Run("read return NotFoundError when bucket control is not found", func(t *testing.T) {
+		id := "not-exist-bucket-name"
+		read, err := svc.Read(&ReadRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   id,
+		})
+
+		require.Nil(t, read)
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
+	})
+
+	t.Run("list", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+
+		require.Equal(t, bucketControl, found[0])
+	})
+
+	t.Run("update", func(t *testing.T) {
+		updated, err := svc.Update(&UpdateRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   bucketName,
+			CanRead:      pointer.NewBool(false),
+			CanWrite:     pointer.NewBool(false),
+		})
+
+		require.NoError(t, err)
+		require.False(t, updated.CanRead.Bool())
+		require.False(t, updated.CanWrite.Bool())
+
+	})
+
+	t.Run("delete return NotFoundError when account is not found", func(t *testing.T) {
+		id := "not-exist-bucket-name"
+		err := svc.Delete(&DeleteRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   id,
+		})
+
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := svc.Delete(&DeleteRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+			BucketName:   bucketName,
+		})
+		require.NoError(t, err)
+
+		found, err := svc.Find(&FindRequest{
+			SiteId:       siteId,
+			PermissionId: permissionId,
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 0)
+	})
+}
+
+func initFakeServer() *httptest.Server {
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Clusters: []*v1.Cluster{
+				{
+					Id:              siteId,
+					ControlPanelUrl: "https://secure.sakura.ad.jp/objectstorage/",
+					DisplayNameEnUs: "Ishikari Site #1",
+					DisplayNameJa:   "石狩第1サイト",
+					DisplayName:     "石狩第1サイト",
+					DisplayOrder:    1,
+					EndpointBase:    "isk01.sakurastorage.jp",
+				},
+			},
+			Permissions: []*v1.Permission{
+				{
+					BucketControls: v1.BucketControls{},
+					DisplayName:    "foo",
+					Id:             v1.PermissionID(permissionId),
+				},
+			},
+		},
+	}
+	return httptest.NewServer(fakeServer.Handler())
+}

--- a/permission/bucketcontrol/update_request.go
+++ b/permission/bucketcontrol/update_request.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type UpdateRequest struct {
+	SiteId       string `service:"-" validate:"required"`
+	PermissionId int64  `service:"-" validate:"required"`
+	BucketName   string `validate:"required"`
+	CanRead      *bool  `validate:"omitempty"`
+	CanWrite     *bool  `validate:"omitempty"`
+}
+
+func (req *UpdateRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/permission/bucketcontrol/update_service.go
+++ b/permission/bucketcontrol/update_service.go
@@ -1,0 +1,80 @@
+// Copyright 2022 The sacloud/object-storage-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bucketcontrol
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	objectstorage "github.com/sacloud/object-storage-api-go"
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
+)
+
+func (s *Service) Update(req *UpdateRequest) (*v1.BucketControl, error) {
+	return s.UpdateWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*v1.BucketControl, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := objectstorage.NewPermissionOp(s.client)
+	permission, err := client.Read(ctx, req.SiteId, req.PermissionId)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for i, bc := range permission.BucketControls {
+		if bc.BucketName.String() == req.BucketName {
+			if req.CanRead != nil {
+				bc.CanRead = v1.CanRead(*req.CanRead)
+			}
+			if req.CanWrite != nil {
+				bc.CanWrite = v1.CanWrite(*req.CanWrite)
+			}
+			found = true
+			permission.BucketControls[i] = bc
+			break
+		}
+	}
+
+	if !found {
+		return nil, &v1.Error404{
+			Detail: v1.ErrorDetail{
+				Code:    http.StatusNotFound,
+				Message: v1.ErrorMessage(fmt.Sprintf("bucket control for %q not found", req.BucketName)),
+			},
+		}
+	}
+
+	permission, err = client.Update(ctx, req.SiteId, req.PermissionId, &v1.UpdatePermissionParams{
+		BucketControls: permission.BucketControls,
+		DisplayName:    permission.DisplayName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, bc := range permission.BucketControls {
+		if bc.BucketName.String() == req.BucketName {
+			return &bc, nil
+		}
+	}
+
+	// 到達しないはず(さくらのクラウド側の障害というケースがあり得るためpanicはさせない)
+	return nil, fmt.Errorf("created bucket-control not found")
+}


### PR DESCRIPTION
論理的な子リソースとしてpermission配下のbucket-controlをサービス対象とし、
Create / Read / Update / Delete + List操作を提供する。

内部の処理はPermissionに対するRead/Updateとなる。
並列実行は考慮されてないのでクライアント側で適切なロックを行う必要がある。

