### PR TITLE
テスト名の変更

### DIFF
--- a/account/accesskey/service_test.go
+++ b/account/accesskey/service_test.go
@@ -31,7 +31,7 @@ var (
 	accountId = "100000000001"
 )
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestAccountAccessKey_CRUD_plus_L(t *testing.T) {
 	fakeServer := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: fakeServer.URL,

--- a/account/service_test.go
+++ b/account/service_test.go
@@ -27,7 +27,7 @@ import (
 
 var siteId = "isk01"
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestAccount_CRUD_plus_L(t *testing.T) {
 	server := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: server.URL,

--- a/bucket/service_acc_test.go
+++ b/bucket/service_acc_test.go
@@ -21,12 +21,13 @@ import (
 	"os"
 	"testing"
 
+	v1 "github.com/sacloud/object-storage-api-go/apis/v1"
 	service "github.com/sacloud/object-storage-service-go"
 	"github.com/sacloud/packages-go/testutil"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccService_CRUD_plus_L(t *testing.T) {
+func TestAccBucket_CRUD_plus_L(t *testing.T) {
 	testutil.PreCheckEnvsFunc(
 		"SAKURACLOUD_ACCESS_TOKEN",
 		"SAKURACLOUD_ACCESS_TOKEN_SECRET",
@@ -73,10 +74,8 @@ func TestAccService_CRUD_plus_L(t *testing.T) {
 			SiteId:    siteId,
 			Id:        notExistName,
 		})
-		require.EqualError(t, err, `bucket "`+notExistName+`" not found`)
-
-		_, errIsNotFoundError := err.(service.NotFoundError)
-		require.True(t, errIsNotFoundError)
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
 	})
 
 	t.Run("delete", func(t *testing.T) {

--- a/permission/accesskey/service_test.go
+++ b/permission/accesskey/service_test.go
@@ -30,7 +30,7 @@ var (
 	permissionId = int64(100000000001)
 )
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestPermissionAccessKey_CRUD_plus_L(t *testing.T) {
 	fakeServer := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: fakeServer.URL,

--- a/permission/bucketcontrol/service_test.go
+++ b/permission/bucketcontrol/service_test.go
@@ -31,7 +31,7 @@ var siteId = "isk01"
 var permissionId = int64(100000001)
 var bucketName = testutil.Random(16, testutil.CharSetAlpha)
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestPermissionBucketControl_CRUD_plus_L(t *testing.T) {
 	fakeServer := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: fakeServer.URL,

--- a/permission/service_test.go
+++ b/permission/service_test.go
@@ -29,7 +29,7 @@ import (
 
 var siteId = "isk01"
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestPermission_CRUD_plus_L(t *testing.T) {
 	server := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: server.URL,

--- a/site/service_test.go
+++ b/site/service_test.go
@@ -27,7 +27,7 @@ import (
 
 var siteId = "isk01"
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestSite_CRUD_plus_L(t *testing.T) {
 	server := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: server.URL,

--- a/site/status/service_test.go
+++ b/site/status/service_test.go
@@ -27,7 +27,7 @@ import (
 
 var siteId = "isk01"
 
-func TestService_CRUD_plus_L(t *testing.T) {
+func TestSiteStatus_CRUD_plus_L(t *testing.T) {
 	server := initFakeServer()
 	client := &objectstorage.Client{
 		APIRootURL: server.URL,


### PR DESCRIPTION
テスト時に-runオプションを指定しやすくするために各テストに固有の名前をつける